### PR TITLE
typst_vello: Use `Default::default()`

### DIFF
--- a/crates/typst_vello/src/lib.rs
+++ b/crates/typst_vello/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub use typst;
 
-use bevy_utils::{default, HashMap};
+use bevy_utils::HashMap;
 use image::{render_image, ImageScene};
 use shape::{convert_path, render_shape, ShapeScene};
 use text::{render_text, TextScene};
@@ -32,9 +32,15 @@ pub struct TypstScene {
 impl TypstScene {
     pub fn from_frame(frame: &Frame) -> Self {
         let size = kurbo::Vec2::new(frame.size().x.to_pt(), frame.size().y.to_pt());
-        let mut typst_scene = TypstScene { size, ..default() };
+        let mut typst_scene = TypstScene {
+            size,
+            ..Default::default()
+        };
 
-        let group_paths = TypstGroup { size, ..default() };
+        let group_paths = TypstGroup {
+            size,
+            ..Default::default()
+        };
         typst_scene.append_group(group_paths);
         typst_scene.handle_frame(
             frame,
@@ -167,7 +173,7 @@ impl TypstScene {
             parent,
             clip_path: group.clip_path.as_ref().map(convert_path),
             label: group.label,
-            ..default()
+            ..Default::default()
         };
 
         // Update state based on group frame.
@@ -246,7 +252,10 @@ pub struct TypstGroupScene {
 
 impl TypstGroupScene {
     pub fn new(group: TypstGroup) -> Self {
-        Self { group, ..default() }
+        Self {
+            group,
+            ..Default::default()
+        }
     }
 }
 
@@ -275,7 +284,7 @@ impl TypstGroup {
         Self {
             scenes: vec![scene],
             parent,
-            ..default()
+            ..Default::default()
         }
     }
 

--- a/crates/typst_vello/src/text.rs
+++ b/crates/typst_vello/src/text.rs
@@ -1,4 +1,3 @@
-use bevy_utils::default;
 use ttf_parser::{GlyphId, OutlineBuilder};
 use typst::{
     layout::{Abs, Ratio, Transform},
@@ -86,7 +85,7 @@ pub fn render_text(
             style: convert_fixed_stroke(stroke),
             brush: convert_paint_to_brush(&stroke.paint, state.size),
         }),
-        ..default()
+        ..Default::default()
     };
 
     let scale = text.size.to_pt() / text.font.units_per_em();

--- a/crates/typst_vello/src/utils.rs
+++ b/crates/typst_vello/src/utils.rs
@@ -1,6 +1,5 @@
 use std::f32::consts::TAU;
 
-use bevy_utils::default;
 use typst::{
     layout::{Quadrant, Size, Transform},
     visualize as viz,
@@ -27,7 +26,7 @@ pub fn convert_fixed_stroke(stroke: &viz::FixedStroke) -> kurbo::Stroke {
         miter_limit,
         start_cap: cap,
         end_cap: cap,
-        ..default()
+        ..Default::default()
     };
 
     if let Some(dash) = &stroke.dash {


### PR DESCRIPTION
This is standard Rust and reduces the dependency on `bevy_utils`.