### PR TITLE
typst_vello: Use `ahash` directly, remove `bevy_utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,7 +5048,7 @@ dependencies = [
 name = "typst_vello"
 version = "0.1.0"
 dependencies = [
- "bevy_utils",
+ "ahash",
  "ttf-parser 0.24.1",
  "typst",
  "vello",

--- a/crates/typst_vello/Cargo.toml
+++ b/crates/typst_vello/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 typst = { workspace = true }
 vello = { workspace = true }
 vello_svg = { workspace = true }
-bevy_utils = "0.14.1"
+ahash = "0.8.11"
 ttf-parser = "0.24.1"
 
 [lints]

--- a/crates/typst_vello/src/lib.rs
+++ b/crates/typst_vello/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub use typst;
 
-use bevy_utils::HashMap;
+use ahash::AHashMap;
 use image::{render_image, ImageScene};
 use shape::{convert_path, render_shape, ShapeScene};
 use text::{render_text, TextScene};
@@ -26,7 +26,7 @@ pub mod utils;
 pub struct TypstScene {
     size: kurbo::Vec2,
     group_scenes: Vec<TypstGroupScene>,
-    group_map: HashMap<Label, Vec<usize>>,
+    group_map: AHashMap<Label, Vec<usize>>,
 }
 
 impl TypstScene {


### PR DESCRIPTION
In `bevy_utils`, the `HashMap` is using `hashbrown` and `ahash`. Since Rust uses `hashbrown` since Rust 1.35, the main (only?) difference is in the use of `ahash`, since this crate isn't looking to target `no_std` currently.