### PR TITLE
Add derive macros for TypstPath and TypstFunc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,7 +2288,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.52.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -2683,6 +2718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f739ee737260d955e330bc83fdeaaf1631f7fb7ed218761d3c04bb13bb7d79df"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4490,7 +4531,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4518,6 +4559,12 @@ dependencies = [
  "hashbrown",
  "serde",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -5352,6 +5399,18 @@ dependencies = [
  "typst-assets 0.11.1",
  "typst_element",
  "typst_vello",
+ "velyst_macros",
+]
+
+[[package]]
+name = "velyst_macros"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "darling",
+ "quote",
+ "syn 2.0.77",
+ "velyst",
 ]
 
 [[package]]
@@ -5655,7 +5714,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ comemo = { workspace = true }
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
 ecow = { workspace = true }
 thiserror = { workspace = true }
+velyst_macros = { version = "0.1.0", path = "crates/velyst_macros" }
 
 [features]
 default = ["embed-fonts"]

--- a/crates/velyst_macros/Cargo.toml
+++ b/crates/velyst_macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "velyst_macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+darling = "0.20.10"
+quote = "1.0.37"
+syn = "2.0.77"
+
+[lints]
+workspace = true
+
+# Needed for tests
+[dev-dependencies]
+bevy.workspace = true
+velyst = { path = "../.." }

--- a/crates/velyst_macros/src/lib.rs
+++ b/crates/velyst_macros/src/lib.rs
@@ -1,0 +1,175 @@
+use darling::{
+    ast::Data,
+    util::{Flag, Ignored},
+    Error, FromDeriveInput, FromField,
+};
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, spanned::Spanned, DeriveInput, Ident, Index};
+
+#[derive(FromDeriveInput)]
+#[darling(forward_attrs(typst_path))]
+struct TypstPathArgs {
+    ident: Ident,
+    #[darling(with = "convert_typst_path")]
+    attrs: TypstPathValue,
+}
+
+struct TypstPathValue(syn::Expr);
+
+fn convert_typst_path(attrs: Vec<syn::Attribute>) -> darling::Result<TypstPathValue> {
+    let mut filtered = attrs
+        .into_iter()
+        .filter(|a| a.path().is_ident("typst_path"));
+
+    let attr = filtered
+        .next()
+        .ok_or(darling::Error::custom("#[typst_path] is required"))?;
+
+    if filtered.next().is_some() {
+        return Err(darling::Error::custom("#[typst_path] can only occur once"));
+    }
+
+    let val = attr.meta.require_name_value()?.value.clone();
+
+    Ok(TypstPathValue(val))
+}
+
+/// Macro for deriving `TypstPath`.
+///
+/// Usage
+/// ```rust
+/// # use velyst_macros::TypstPath;
+/// #[derive(TypstPath)]
+/// #[typst_path = "path_to_file.typ"] // Path relative to bevy asset dir
+/// struct MyTypstFile;
+/// ```
+#[proc_macro_derive(TypstPath, attributes(typst_path))]
+pub fn derive_typst_path(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let TypstPathArgs {
+        ident,
+        attrs: TypstPathValue(path),
+    } = match TypstPathArgs::from_derive_input(&ast) {
+        Ok(t) => t,
+        Err(e) => return e.write_errors().into(),
+    };
+
+    quote! {
+        impl velyst::renderer::TypstPath for #ident {
+            fn path() -> &'static str {
+                #path
+            }
+        }
+    }
+    .into()
+}
+
+#[derive(FromDeriveInput)]
+#[darling(supports(struct_any), attributes(typst_func))]
+struct TypstFuncArgs {
+    ident: Ident,
+    data: Data<Ignored, TypstFuncField>,
+    name: String,
+    #[darling(default)]
+    layer: usize,
+}
+
+#[derive(FromField)]
+#[darling(attributes(typst_func))]
+struct TypstFuncField {
+    ident: Option<Ident>,
+    named: Flag,
+}
+
+/// Macro for deriving `TypstFunc`.
+///
+/// Usage
+/// ```rust
+/// # use velyst_macros::TypstFunc;
+/// # use bevy::prelude::*;
+/// #[derive(Resource, TypstFunc)]
+/// #[typst_func(name = "main", layer = 0)] // layer is optional
+/// struct MainFunc {
+///     width: f64,
+///     height: f64,
+///     #[typst_func(named)] // use as a named argument
+///     animate: f64,
+/// }
+/// ```
+#[proc_macro_derive(TypstFunc, attributes(typst_func))]
+pub fn derive_typst_func(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let TypstFuncArgs {
+        ident,
+        data,
+        name,
+        layer,
+    } = match TypstFuncArgs::from_derive_input(&ast) {
+        Ok(t) => t,
+        Err(e) => return e.write_errors().into(),
+    };
+
+    let fields = data.take_struct().expect("Can never be an enum");
+
+    let mut errors = Error::accumulator();
+
+    let field_tokens = fields
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, field)| {
+            errors.handle_in(|| {
+                Ok(if field.named.is_present() {
+                    let ident = field.ident.as_ref().ok_or(
+                        Error::custom("#[typst_func(named)] is only supported on named fields")
+                            .with_span(&field.ident.span()),
+                    )?;
+
+                    let name = ident.to_string();
+
+                    quote! {
+                        args.push_named(#name, self.#ident);
+                    }
+                } else {
+                    let ident = field
+                        .ident
+                        .as_ref()
+                        .map(|f| f.to_token_stream())
+                        .unwrap_or(Index::from(i).to_token_stream());
+
+                    quote! {
+                        args.push(self.#ident);
+                    }
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if let Err(e) = errors.finish() {
+        return e.write_errors().into();
+    }
+
+    quote! {
+        impl velyst::renderer::TypstFunc for #ident {
+            fn func_name(&self) -> &str {
+                #name
+            }
+
+            fn content(&self, func: velyst::typst::foundations::Func) -> velyst::typst::foundations::Content {
+                velyst::typst::foundations::NativeElement::pack(
+                    velyst::typst_element::elem::context(func, |args| {
+                        #(#field_tokens)*
+                    })
+                )
+            }
+
+            fn render_layers(&self) -> bevy::render::view::RenderLayers {
+                bevy::render::view::RenderLayers::layer(#layer)
+            }
+
+        }
+    }
+    .into()
+}

--- a/crates/velyst_macros/src/lib.rs
+++ b/crates/velyst_macros/src/lib.rs
@@ -111,7 +111,7 @@ impl TypstFuncField {
 ///     #[typst_func(named)] // use as a named argument
 ///     animate: f64,
 ///     #[typst_func(named = "bar")] // use as a named argument with the name "bar"
-///     foo: f64,
+///     foo: String,
 /// }
 /// ```
 #[proc_macro_derive(TypstFunc, attributes(typst_func))]
@@ -147,14 +147,12 @@ pub fn derive_typst_func(input: TokenStream) -> TokenStream {
                     Some(named) => {
                         let name = named?;
                         quote! {
-                            args.push_named(#name, self.#ident);
+                            args.push_named(#name, self.#ident.clone());
                         }
                     }
-                    None => {
-                        quote! {
-                            args.push(self.#ident);
-                        }
-                    }
+                    None => quote! {
+                        args.push(self.#ident.clone());
+                    },
                 };
 
                 Ok(field_token)

--- a/examples/game_ui.rs
+++ b/examples/game_ui.rs
@@ -73,56 +73,25 @@ fn perf_metrics(time: Res<Time>, mut perf_metrics: ResMut<PerfMetricsFunc>) {
     perf_metrics.elapsed_time = elapsed_time;
 }
 
-struct GameUi;
-
-impl TypstPath for GameUi {
-    fn path() -> &'static str {
-        "typst/game_ui.typ"
-    }
-}
-
-#[derive(Resource, Default)]
+#[derive(TypstFunc, Resource, Default)]
+#[typst_func(name = "main")]
 pub struct MainFunc {
     width: f64,
     height: f64,
     perf_metrics: Content,
+    #[typst_func(named)]
     btn_highlight: String,
+    #[typst_func(named)]
     animate: f64,
 }
 
-impl TypstFunc for MainFunc {
-    fn func_name(&self) -> &str {
-        "main"
-    }
-
-    fn content(&self, func: foundations::Func) -> Content {
-        elem::context(func, |args| {
-            args.push(self.width);
-            args.push(self.height);
-            args.push(self.perf_metrics.clone());
-            args.push_named("btn_highlight", self.btn_highlight.clone());
-            args.push_named("animate", self.animate);
-        })
-        .pack()
-    }
-}
-
-#[derive(Resource, Default)]
+#[derive(TypstFunc, Resource, Default)]
+#[typst_func(name = "perf_metrics")]
 pub struct PerfMetricsFunc {
     fps: f64,
     elapsed_time: f64,
 }
 
-impl TypstFunc for PerfMetricsFunc {
-    fn func_name(&self) -> &str {
-        "perf_metrics"
-    }
-
-    fn content(&self, func: foundations::Func) -> Content {
-        elem::context(func, |args| {
-            args.push(self.fps);
-            args.push(self.elapsed_time);
-        })
-        .pack()
-    }
-}
+#[derive(TypstPath)]
+#[typst_path = "typst/game_ui.typ"]
+struct GameUi;

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_vello::VelloPlugin;
-use velyst::{prelude::*, typst_element::prelude::*, VelystPlugin};
+use velyst::{prelude::*, VelystPlugin};
 
 fn main() {
     App::new()
@@ -38,32 +38,15 @@ fn main_func(
     main_func.animate = time.elapsed_seconds_f64();
 }
 
-struct HelloWorld;
-
-impl TypstPath for HelloWorld {
-    fn path() -> &'static str {
-        "typst/hello_world.typ"
-    }
-}
-
-#[derive(Resource, Default)]
+#[derive(TypstFunc, Resource, Default)]
+#[typst_func(name = "main")]
 struct MainFunc {
     width: f64,
     height: f64,
+    #[typst_func(named)]
     animate: f64,
 }
 
-impl TypstFunc for MainFunc {
-    fn func_name(&self) -> &str {
-        "main"
-    }
-
-    fn content(&self, func: foundations::Func) -> Content {
-        elem::context(func, |args| {
-            args.push(self.width);
-            args.push(self.height);
-            args.push_named("animate", self.animate);
-        })
-        .pack()
-    }
-}
+#[derive(TypstPath)]
+#[typst_path = "typst/hello_world.typ"]
+struct HelloWorld;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod prelude {
         VelystCommandExt, VelystScene, VelystSet,
     };
     pub use crate::world::{TypstWorld, TypstWorldRef};
+    pub use velyst_macros::{TypstFunc, TypstPath};
 }
 
 pub mod asset;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -375,12 +375,10 @@ pub struct TypstLabel(TypLabel);
 pub trait TypstFunc: Resource {
     fn func_name(&self) -> &str;
 
-    // TODO: Create macro to automatically generate the render layers function.
     fn render_layers(&self) -> RenderLayers {
         RenderLayers::layer(0)
     }
 
-    // TODO: Create macro to automatically generate the content function.
     fn content(&self, func: foundations::Func) -> Content;
 
     fn compile(&self, scope: &foundations::Scope) -> Content {
@@ -394,7 +392,6 @@ pub trait TypstFunc: Resource {
     }
 }
 
-// TODO: Create macro to easily set the path.
 pub trait TypstPath: Send + Sync + 'static {
     fn path() -> &'static str;
 }


### PR DESCRIPTION
I tried tackling adding proc macros for `TypstFunc` and `TypstPath`.
I'm not really sure about the quality of this code because I've never really worked with proc macros before, but I tried writing it to be as readable as possible.

From my testing, everything seems to work as expected.

This PR uses the [darling](https://crates.io/crates/darling) library for most of the heavy parsing which reduces the code length by a lot, but it does result in code which feels a lot more like "magic" which might not be desirable.

Closes https://github.com/voxell-tech/velyst/issues/9, closes https://github.com/voxell-tech/velyst/issues/8.