### PR TITLE
Add scene visibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,11 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
+# Local dependencies
 typst_element = { version = "0.1.0", path = "crates/typst_element" }
 typst_vello = { version = "0.1.0", path = "crates/typst_vello" }
+velyst_macros = { version = "0.1.0", path = "crates/velyst_macros" }
+
 bevy = { workspace = true }
 bevy_vello = { workspace = true }
 typst = { workspace = true }
@@ -49,7 +52,6 @@ comemo = { workspace = true }
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
 ecow = { workspace = true }
 thiserror = { workspace = true }
-velyst_macros = { version = "0.1.0", path = "crates/velyst_macros" }
 
 [features]
 default = ["embed-fonts"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod prelude {
     pub use crate::asset::TypstAsset;
     pub use crate::renderer::{
         TypstAssetHandle, TypstContent, TypstContext, TypstFunc, TypstLabel, TypstPath,
-        VelystCommandExt, VelystScene, VelystSet,
+        VelystAppExt, VelystScene, VelystSet,
     };
     pub use crate::world::{TypstWorld, TypstWorldRef};
 }


### PR DESCRIPTION
# Changelog

- `VelystScene<F: TypstFunc>`: VelystScene generic must now implement `TypstFunc`. This prevents querying `VelystScene` with a non-valid generic in a system.
- `VelystScene` now has a new field: `pub visibility: Visibility,` that determines the visibility of the scene.